### PR TITLE
ElasticSearch upgrade fix for cve-2021-22147

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,7 @@ dependencies {
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.2.RELEASE'
   implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4'
   implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
-  implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.13.4'
+  implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.14.0'
 
   implementation group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A


### Change description ###

ElasticSearch upgrade fix for CVE-2021-22147 as described here: https://nvd.nist.gov/vuln/detail/CVE-2021-22147


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
