### PR TITLE
Revert "RIA-6892 Solving additional CVEs."

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.0'
-  id 'org.springframework.boot' version '2.7.11'
+  id 'org.springframework.boot' version '2.7.2'
   id 'uk.gov.hmcts.java' version '0.12.5'
-  id 'org.owasp.dependencycheck' version '8.2.1'
+  id 'org.owasp.dependencycheck' version '8.0.2'
   id 'com.github.ben-manes.versions' version '0.28.0'
   id 'org.sonarqube' version '2.8'
   id "io.freefair.lombok" version "5.1.0"
@@ -178,12 +178,18 @@ dependencyCheck {
 dependencyManagement {
   dependencies {
 
-    dependencySet(group: 'org.yaml', version: '2.0') {
+    dependencySet(group: 'org.yaml', version: '1.33') {
       entry 'snakeyaml'
     }
 
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.73') {
+      entry 'tomcat-embed-core'
+      entry 'tomcat-embed-el'
+      entry 'tomcat-embed-websocket'
+    }
+
     // CVE-2018-10237 - Unbounded memory allocation
-    dependencySet(group: 'com.google.guava', version: '31.1-jre') {
+    dependencySet(group: 'com.google.guava', version: '30.0-jre') {
       entry 'guava'
     }
 
@@ -191,28 +197,34 @@ dependencyManagement {
       entry 'commons-fileupload'
     }
 
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.15.0') {
+    dependencySet(group: 'org.springframework.security', version: '5.7.5') {
+      entry 'spring-security-crypto'
+      entry 'spring-security-core'
+      entry 'spring-security-config'
+      entry 'spring-security-web'
+      entry 'spring-security-test'
+      entry 'spring-security-oauth2-client'
+      entry 'spring-security-oauth2-core'
+      entry 'spring-security-oauth2-jose'
+      entry 'spring-security-oauth2-resource-server'
+    }
+
+    //CVE-2021-42550
+    dependencySet(group: 'ch.qos.logback', version: '1.2.10') {
+      entry 'logback-classic'
+      entry 'logback-core'
+    }
+
+    //CVE-2021-44228, CVE-2021-44832, CVE-2021-45046
+    dependencySet(group: 'org.apache.logging.log4j', version: '2.17.1') {
+      entry 'log4j-api'
+      entry 'log4j-to-slf4j'
+    }
+
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.14.1') {
       entry 'jackson-databind'
       entry 'jackson-core'
-      entry 'jackson-annotations'
     }
-
-    dependencySet(group: 'com.fasterxml.jackson.dataformat', version: '2.15.0') {
-      entry 'jackson-dataformat-yaml'
-      entry 'jackson-dataformat-cbor'
-      entry 'jackson-dataformat-smile'
-    }
-
-    dependencySet(group: 'com.fasterxml.jackson.datatype', version: '2.15.0') {
-      entry 'jackson-datatype-jsr310'
-      entry 'jackson-datatype-jdk8'
-    }
-
-    dependencySet(group: 'com.fasterxml.jackson.module', version: '2.15.0') {
-      entry 'jackson-module-parameter-names'
-      entry 'jackson-module-afterburner'
-    }
-
   }
 }
 
@@ -226,6 +238,7 @@ def versions = [
   junit           : '5.6.2',
   junitPlatform   : '1.6.2',
   reformLogging   : '5.1.7',
+  springBoot      : '2.7.2',
   pact_version    : '3.5.24',
   serenity        : '2.2.12'
 ]
@@ -289,7 +302,7 @@ dependencies {
   }
 
   testImplementation libraries.junit5
-  testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test') {
+  testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot, {
     exclude group: 'junit', module: 'junit'
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
@@ -303,7 +316,7 @@ dependencies {
 
   testImplementation group: 'org.pitest', name: 'pitest', version: '1.5.2'
 
-  testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test') {
+  testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot) {
     exclude group: "com.vaadin.external.google", module: "android-json"
   }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -60,7 +60,8 @@
      <cve>CVE-2023-35116</cve>
      <cve>CVE-2023-2976</cve>
      <cve>CVE-2023-34981</cve>
-    <cve>CVE-2022-1471</cve>
+     <cve>CVE-2022-1471</cve>
+     <cve>CVE-2023-28709</cve>
   </suppress>
 
      <!-- end of temporary suppressions -->

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,10 +20,49 @@
       ]]</notes>
     <cve>CVE-2022-45688</cve>
   </suppress>
-  <suppress until="2023-07-30">
-    <cve>CVE-2023-20883</cve>
-    <cve>CVE-2023-35116</cve>
-    <cve>CVE-2023-2976</cve>
-    <cve>CVE-2023-34981</cve>
+  <suppress>
+    <notes>False positive spring-security-crypto-5.7.1.jar</notes>
+    <cve>CVE-2020-5408</cve>
   </suppress>
+  <suppress>
+    <!-- A temp directory creation vulnerability exists in all versions of Guava, allowing an attacker
+    with access to the machine to potentially access data in a temporary directory created by the Guava API
+    com.google.common.io.Files.createTempDir(). By default, on unix-like systems,
+    the created directory is world-readable (readable by an attacker with access to the system). The method in question
+     has been marked @Deprecated in versions 30.0 and later and should not be used. For Android developers,
+      we recommend choosing a temporary directory API provided by Android, such as context.getCacheDir().
+      For other Java developers, we recommend migrating to the Java 7 API java.nio.file.Files.createTempDirectory()
+      which explicitly configures permissions of 700, or configuring the Java runtime's java.io.tmpdir
+      system property to point to a location whose permissions are appropriately configured.-->
+    <notes><![CDATA[
+            This CVE is for an older version of guava which only the checkstyle gradle plugin is currently using.
+        ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com.google.guava/guava@.*$</packageUrl>
+    <cve>CVE-2020-8908</cve>
+  </suppress>
+          <!-- The following CVEs are suppressed for the purpose of getting the current PR onto the preview environment
+         They should still be addressed -->
+  <suppress until="2023-05-27">
+     <notes><![CDATA[
+                  file name: json-smart-2.4.8.jar
+                ]]>
+     </notes>
+     <cve>CVE-2021-31684</cve>
+     <cve>CVE-2023-1370</cve>
+  </suppress>
+  <suppress until="2023-08-30">
+     <cve>CVE-2023-20863</cve>
+     <cve>CVE-2023-20862</cve>
+     <cve>CVE-2023-20861</cve>
+     <cve>CVE-2023-20860</cve>
+     <cve>CVE-2023-20873</cve>
+     <cve>CVE-2023-20883</cve>
+     <cve>CVE-2023-35116</cve>
+     <cve>CVE-2023-2976</cve>
+     <cve>CVE-2023-34981</cve>
+    <cve>CVE-2022-1471</cve>
+  </suppress>
+
+     <!-- end of temporary suppressions -->
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
This reverts commit 69229c89

That commit seems to have introduced here the same problems it caused in ia-home-office-integration-api, preventing Azure Vault secrets to be loaded and Application Insights from logging. The change will be reverted while we figure out what went wrong.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
